### PR TITLE
升级依赖与使用优化

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ conda create --name dreamo python=3.10
 conda activate dreamo
 # install dependent packages
 pip install -r requirements.txt
+# install dependent packages for 50XX GPUS
+pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128
 ```
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-torch==2.6.0
-torchvision==0.21.0
+torch==2.7.0
+torchvision
 protobuf
 optimum-quanto==0.2.7
 einops
 timm
-diffusers==0.31.0
+diffusers==0.33.1
 transformers==4.45.2
 sentencepiece
 gradio


### PR DESCRIPTION
1.升级torch到2.7.0，方便50系显卡使用
2.升级diffusers到0.33.1，并修复相关代码
3.修改卸载模型逻辑，减少等待时间
4.添加缓存清理
5.添加更多启动参数
6.添加了一个种子输出，用来提示跑图结束