### PR TITLE
使用 Nunchaku 实现2~4倍高速推理 <7GB 低显存占用

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ dmypy.json
 .pyre/
 
 .idea/
+.vscode/

--- a/dreamo/transformer.py
+++ b/dreamo/transformer.py
@@ -88,17 +88,29 @@ def flux_transformer_forward(
     hidden_states = self.x_embedder(hidden_states)
     # add task and idx embedding
     if embeddings is not None:
+        # Ensure embeddings is on the same device as hidden_states
+        if embeddings.device != hidden_states.device:
+            embeddings = embeddings.to(hidden_states.device)
         hidden_states = hidden_states + embeddings
 
-    timestep = timestep.to(hidden_states.dtype) * 1000
-    guidance = guidance.to(hidden_states.dtype) * 1000 if guidance is not None else None
+    # Ensure timestep is on the correct device and maintains its dtype for scaling,
+    # then ensure it's LongTensor for time_text_embed
+    original_timestep_dtype = timestep.dtype
+    timestep_scaled = timestep.to(hidden_states.device, dtype=hidden_states.dtype) * 1000
+
+    temb_guidance = None
+    if guidance is not None:
+        # Ensure guidance is on the correct device and maintains its dtype for scaling
+        original_guidance_dtype = guidance.dtype
+        guidance_scaled = guidance.to(hidden_states.device, dtype=hidden_states.dtype) * 1000
+        temb_guidance = guidance_scaled
 
     temb = (
-        self.time_text_embed(timestep, pooled_projections)
+        self.time_text_embed(timestep_scaled.long() if hidden_states.dtype == torch.float32 else timestep_scaled, pooled_projections.to(hidden_states.device)) # Ensure pooled_projections is also on the correct device
         if guidance is None
-        else self.time_text_embed(timestep, guidance, pooled_projections)
+        else self.time_text_embed(timestep_scaled.long() if hidden_states.dtype == torch.float32 else timestep_scaled, temb_guidance, pooled_projections.to(hidden_states.device)) # Ensure pooled_projections is also on the correct device
     )
-    encoder_hidden_states = self.context_embedder(encoder_hidden_states)
+    encoder_hidden_states = self.context_embedder(encoder_hidden_states.to(hidden_states.device)) # Ensure encoder_hidden_states is on the correct device
 
     if txt_ids.ndim == 3:
         # logger.warning(

--- a/dreamo/utils.py
+++ b/dreamo/utils.py
@@ -17,7 +17,6 @@ import re
 
 import cv2
 import numpy as np
-import PIL.Image
 import torch
 from torchvision.utils import make_grid
 

--- a/dreamo/utils.py
+++ b/dreamo/utils.py
@@ -17,6 +17,7 @@ import re
 
 import cv2
 import numpy as np
+import PIL.Image
 import torch
 from torchvision.utils import make_grid
 
@@ -230,3 +231,16 @@ def convert_flux_lora_to_diffusers(old_state_dict):
     #     raise ValueError(f"`old_state_dict` should be at this point but has: {list(old_state_dict.keys())}.")
 
     return new_state_dict
+
+
+def get_device(device='auto'):
+    """Automatically detect the best available device"""
+    if device != 'auto':
+        return torch.device(device)
+    
+    if torch.cuda.is_available():
+        return torch.device('cuda')
+    elif torch.backends.mps.is_available():
+        return torch.device('mps')
+    else:
+        return torch.device('cpu')

--- a/dreamo_generator.py
+++ b/dreamo_generator.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
+# Copyright 2024 Black Forest Labs and The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 import os
 import cv2

--- a/dreamo_generator.py
+++ b/dreamo_generator.py
@@ -1,0 +1,236 @@
+
+import os
+import cv2
+import sys
+import numpy as np
+import torch
+import time  # Added for profiling
+from PIL import Image
+from huggingface_hub import hf_hub_download
+from torchvision.transforms.functional import normalize
+
+from tools import BEN2
+from facexlib.utils.face_restoration_helper import FaceRestoreHelper
+from dreamo.dreamo_pipeline import DreamOPipeline
+from dreamo.utils import (
+    get_device,
+    img2tensor,
+    tensor2img,
+    resize_numpy_image_area,
+    resize_numpy_image_long,
+    )
+
+
+class Generator:
+    def __init__(self, **args):
+        
+        # Parsing parameters
+        self.version = args.pop("version", "v1.1")
+        self.offload = args.pop("offload", True) 
+        self.no_turbo = args.pop("no_turbo", False)
+        self.quant = args.pop("quant", "default") # Quantize to use: default, int8, nunchaku
+        self.device = get_device(args.pop("device", "auto")) # Device to use: auto, cuda, mps, or cpu
+        print(f"Using device: {self.device} offload: {self.offload} quant: {self.quant}")
+        
+        # preprocessing models
+        # background remove model: BEN2
+        self.bg_rm_model = BEN2.BEN_Base().to(self.device).eval()
+        hf_hub_download(repo_id='PramaLLC/BEN2', filename='BEN2_Base.pth', local_dir='models')
+        self.bg_rm_model.loadcheckpoints('models/BEN2_Base.pth')
+        # face crop and align tool: facexlib
+        self.face_helper = FaceRestoreHelper(
+            upscale_factor=1,
+            face_size=512,
+            crop_ratio=(1, 1),
+            det_model='retinaface_resnet50',
+            save_ext='png',
+            device=self.device,
+        )
+        if self.offload:
+            self.ben_to_device(torch.device('cpu'))
+            self.facexlib_to_device(torch.device('cpu'))
+            
+        # Loading and initializing the dreamo pipeline.
+        # If there is a new optimization solution, you can add it here.
+        self.dreamo_pipeline:DreamOPipeline = None
+        if self.quant == "nunchaku":
+            self.dreamo_pipeline_init_nunchaku() # nunchaku,  offload 6.5GB VRAM.
+        else:
+            self.dreamo_pipeline_init_default() # default or int8, offload 24GB or 16GB VRAM.
+
+            
+    # Default full precision or int8 quantized inference
+    def dreamo_pipeline_init_default(self):
+        # load dreamo
+        model_root = 'black-forest-labs/FLUX.1-dev'
+        if os.path.exists(f'./models/{model_root}'):model_root = f'./models/{model_root}' # 兼容目录 ./models
+        self.dreamo_pipeline = DreamOPipeline.from_pretrained(model_root, torch_dtype=torch.bfloat16)
+        self.dreamo_pipeline.load_dreamo_model(self.device, use_turbo=self.no_turbo)
+        # Quantize the model using int8, which may take some time
+        if self.quant == "int8":
+            # pip install optimum
+            from optimum.quanto import freeze, qint8, quantize
+            print('start quantize')
+            quantize(self.dreamo_pipeline.transformer, qint8)
+            freeze(self.dreamo_pipeline.transformer)
+            quantize(self.dreamo_pipeline.text_encoder_2, qint8)
+            freeze(self.dreamo_pipeline.text_encoder_2)
+            print('done quantize')
+        self.dreamo_pipeline = self.dreamo_pipeline.to(self.device)
+        if self.offload:
+            self.dreamo_pipeline.enable_model_cpu_offload()
+            self.dreamo_pipeline.offload = True
+        else:
+            self.dreamo_pipeline.offload = False
+        
+        print(f"\n[Profiler] Total Generator initialization ({self.quant}).")
+        pass
+        
+    # Fast inference using nunchaku by juntaosun  
+    def dreamo_pipeline_init_nunchaku(self):
+        """ 使用 Nunchaku 实现2-4倍高速推理 <7GB 低显存占用。by juntaosun  
+            参考速度：3080 显卡 1024x1024 ,12 steps, 15-20s 生成.     
+            Description: Use Nunchaku to achieve 2-4 times faster inference and <7GB low VRAM usage.    
+            Reference speed: 3080 graphics card 1024x1024, 12 steps, 15-20s to generate.  
+        """
+        
+        try:
+            # 依赖检测：nunchaku 需调用 SanaTransformer2DModel。条件版本 >=0.32.2
+            from diffusers import SanaTransformer2DModel
+        except Exception as e:
+            raise ValueError("nunchaku requires version:\n 👉️ pip install diffusers==0.32.2")
+        
+        try:
+            # 依赖检测：The current version has been tested: nunchaku v0.3.x
+            from nunchaku import NunchakuFluxTransformer2dModel
+            from nunchaku.caching.diffusers_adapters.flux import apply_cache_on_pipe # flux
+            from nunchaku.utils import get_precision
+        except Exception as e:
+            message = "\n--------------------------------------------------------------------\n"
+            message += f"👉️ 缺失 nunchaku，请前往链接安装 (Missing nunchaku, please go to the link to install it):\n"
+            message += f"https://github.com/mit-han-lab/nunchaku/releases/\n"
+            message += "--------------------------------------------------------------------\n"
+            raise ValueError(message)
+    
+        
+        print("===================== Nunchaku =====================")
+        # download models and load file (~7GB)
+        precision = get_precision()  # auto-detect your precision is 'int4' or 'fp4' based on your GPU
+        svdq_filename = f"svdq-{precision}_r32-flux.1-dev.safetensors"
+        print(f'svdq_filename: {svdq_filename}')
+        hf_hub_download(repo_id='mit-han-lab/nunchaku-flux.1-dev', filename=svdq_filename, local_dir='models')
+        transformer:NunchakuFluxTransformer2dModel = NunchakuFluxTransformer2dModel.from_pretrained(
+            f"models/{svdq_filename}",
+            offload=self.offload,
+        )
+        
+        print("\n[Profiler] Loading DreamOPipeline from pretrained (FLUX base)...")
+        dreamo_pipeline_load_start_time = time.time()
+        model_root = 'black-forest-labs/FLUX.1-dev'
+        if os.path.exists(f'./models/{model_root}'):model_root = f'./models/{model_root}' # 兼容目录 ./models
+        self.dreamo_pipeline:DreamOPipeline = DreamOPipeline.from_pretrained(model_root, transformer=transformer, torch_dtype=torch.bfloat16)
+        print(f"[Profiler] DreamOPipeline (FLUX base) loaded in {time.time() - dreamo_pipeline_load_start_time:.2f} seconds.")
+        
+        print(f"\n[Profiler] Loading DreamO specific models into pipeline... version: {self.version}")
+        dreamo_specific_load_start_time = time.time()
+        self.dreamo_pipeline.load_dreamo_model_nunchaku(self.device, use_turbo=not self.no_turbo, version=self.version)
+        print(f"[Profiler] DreamO specific models loaded in {time.time() - dreamo_specific_load_start_time:.2f} seconds.")
+            
+        print(f"\n[Profiler] Moving final DreamOPipeline to device ({self.device})...")
+        to_device_start_time = time.time()
+        if self.offload:
+            self.dreamo_pipeline.enable_model_cpu_offload()
+            self.dreamo_pipeline.offload = True
+        else:
+            self.dreamo_pipeline.offload = False
+        print(f"[Profiler] DreamOPipeline moved to device (with explicit component moves) in {time.time() - to_device_start_time:.2f} seconds.")
+            
+        #  参数用于控制是否启用注意力切片技术。当 GPU 显存有限时，启用此参数可以减少 VRAM 使用，但可能会牺牲一定的计算速度。
+        self.dreamo_pipeline.enable_attention_slicing()
+        self.dreamo_pipeline.enable_vae_tiling()
+        
+        # nunchaku CPU Offloading  CPU 卸载,初始化时设置 offload=True，然后调用：
+        self.dreamo_pipeline.enable_sequential_cpu_offload()
+        # nunchaku 块缓存,建议的值为 0.12，它为 50 级降噪提供高达 2× 的加速。对于 turbo 12步时建议>=0.05
+        apply_cache_on_pipe(self.dreamo_pipeline, residual_diff_threshold=0.05)
+
+        print(f"\n[Profiler] Total Generator initialization ({self.quant}).")
+        pass
+
+    def ben_to_device(self, device):
+        self.bg_rm_model.to(device)
+
+    def facexlib_to_device(self, device):
+        self.face_helper.face_det.to(device)
+        self.face_helper.face_parse.to(device)
+
+    @torch.no_grad()
+    def get_align_face(self, img):
+        # the face preprocessing code is same as PuLID
+        self.face_helper.clean_all()
+        image_bgr = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+        self.face_helper.read_image(image_bgr)
+        self.face_helper.get_face_landmarks_5(only_center_face=True)
+        self.face_helper.align_warp_face()
+        if len(self.face_helper.cropped_faces) == 0:
+            return None
+        align_face = self.face_helper.cropped_faces[0]
+
+        input = img2tensor(align_face, bgr2rgb=True).unsqueeze(0) / 255.0
+        input = input.to(self.device)
+        parsing_out = self.face_helper.face_parse(normalize(input, [0.485, 0.456, 0.406], [0.229, 0.224, 0.225]))[0]
+        parsing_out = parsing_out.argmax(dim=1, keepdim=True)
+        bg_label = [0, 16, 18, 7, 8, 9, 14, 15]
+        bg = sum(parsing_out == i for i in bg_label).bool()
+        white_image = torch.ones_like(input)
+        # only keep the face features
+        face_features_image = torch.where(bg, white_image, input)
+        face_features_image = tensor2img(face_features_image, rgb2bgr=False)
+
+        return face_features_image
+    
+    # Input condition preprocessing
+    def pre_condition(self, ref_images, ref_tasks, ref_res, seed):
+        ref_conds = []
+        debug_images = []
+        for idx, (ref_image, ref_task) in enumerate(zip(ref_images, ref_tasks)):
+            if ref_image is not None:
+                if ref_task == "id":
+                    if self.offload:
+                        self.facexlib_to_device(self.device)
+                    ref_image = resize_numpy_image_long(ref_image, 1024)
+                    ref_image = self.get_align_face(ref_image)
+                    if self.offload:
+                        self.facexlib_to_device(torch.device('cpu'))
+                elif ref_task != "style":
+                    if self.offload:
+                        self.ben_to_device(self.device)
+                    ref_image = self.bg_rm_model.inference(Image.fromarray(ref_image))
+                    if self.offload:
+                        self.ben_to_device(torch.device('cpu'))
+                if ref_task != "id":
+                    ref_image = resize_numpy_image_area(np.array(ref_image), ref_res * ref_res)
+                debug_images.append(ref_image)
+                ref_image = img2tensor(ref_image, bgr2rgb=False).unsqueeze(0) / 255.0
+                ref_image = 2 * ref_image - 1.0
+                ref_conds.append(
+                    {
+                        'img': ref_image,
+                        'task': ref_task,
+                        'idx': idx + 1,
+                    }
+                )
+        # cleaning
+        self.torch_empty_cache()
+        seed = torch.Generator(device="cpu").seed() if seed == -1 else int(seed)
+        return ref_conds, debug_images, seed
+    
+    # Try cleaning the GPU
+    def torch_empty_cache(self):
+        try:
+            if "cuda" in str(self.device):
+                torch.cuda.empty_cache()
+            elif "mps" in str(self.device):
+                torch.mps.empty_cache()
+        except Exception as e:
+            pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ protobuf
 optimum-quanto==0.2.7
 einops
 timm
-diffusers==0.31.0
+diffusers==0.32.2
 transformers==4.45.2
 sentencepiece
 gradio

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ protobuf
 optimum-quanto==0.2.7
 einops
 timm
-diffusers==0.32.2
+diffusers==0.33.1
 transformers==4.45.2
 sentencepiece
 gradio


### PR DESCRIPTION
我尝试第一次给 DreamO 贡献一份小小的 PR~ 😉  

【特色内容】 
  👉️ 新增 nunchaku 支持 ，可达 2~4 倍高速推理，低显存 <~7GB 占用，三个参考图。    
  👉️ 现在，它可在消费级GPU比如 >8GB 显卡上畅玩，祝大家玩的开心！🎉   
  👉️ 推理，仅需数十秒，即可生成 1024x1024 图像！（基于 NVIDIA RTX 3080 实测）  

【主要变化】本次 PR 改动如下， 兼容 v1 或最新 v1.1 模型：    
（1）dreamo_pipeline.py ：新增兼容 load_dreamo_model_nunchaku  
（2）dreamo_generator.py：新增，负责核心加载或量化逻辑处理。  
（3）app.py ： 用户 webUI 界面代码更整洁， 实时推理进度展示。   
（4）requirements.txt ，将依赖升级到 diffusers==0.32.2  

【显存占用】不同量化对显存的影响，对比数据： 
| --quant | VRAM | mark |  
|:-|-:|:-:|  
| default | 24GB | ⚠️  |  
| int8 | 16GB | ⚠️  |  
| nunchaku | 6.5GB | ✅ |  
 
app.py 启动参数：  
```
--quant ：default or int8 or nunchaku  
```

【安装说明】Nunchaku 最新版本安装详见：    
https://github.com/mit-han-lab/nunchaku


【运行说明】   
运行 app.py，打开 webui 页面，使用 nunchaku 快速推理。   

```
parser.add_argument('--quant', type=str, default='nunchaku', help='Quantize to use: default, int8, nunchaku')
```
---

【Featured Content】
Added nunchaku support, up to 2~4 times faster inference, low video memory usage <~7GB, three reference images.
Now, it can be played on consumer-grade GPUs such as >8GB graphics cards, I wish you all a happy game! 🎉

【Installation instructions】For the latest version of Nunchaku installation, see:
https://github.com/mit-han-lab/nunchaku

app.py startup parameters:
```
--quant ：default or int8 or nunchaku
```

【Running instructions】
Run app.py, open the webui page, and use nunchaku for fast inference.


![Image](https://github.com/user-attachments/assets/86a48af3-312b-4005-8b6f-e37135d13896)  
```
a person playing guitar in the street，lookat the viewer.  
```

![image](https://github.com/user-attachments/assets/9b7cce6a-06d8-44c7-8204-70f5efbcf34f)  

