### PR TITLE
Dynamic FBcache parameter with nunchaku

### DIFF
--- a/dreamo_generator.py
+++ b/dreamo_generator.py
@@ -109,7 +109,6 @@ class Generator:
         try:
             # 依赖检测：The current version has been tested: nunchaku v0.3.x
             from nunchaku import NunchakuFluxTransformer2dModel
-            from nunchaku.caching.diffusers_adapters.flux import apply_cache_on_pipe # flux
             from nunchaku.utils import get_precision
         except Exception as e:
             message = "\n--------------------------------------------------------------------\n"
@@ -144,7 +143,6 @@ class Generator:
             
         print(f"\n[Profiler] Moving final DreamOPipeline to device ({self.device})...")
         to_device_start_time = time.time()
-        apply_cache_on_pipe(self.dreamo_pipeline, residual_diff_threshold=0.05)
         if self.offload:
             self.dreamo_pipeline.enable_sequential_cpu_offload()
             self.dreamo_pipeline.offload = True


### PR DESCRIPTION
Closes #103

This PR introduces support for the dynamic modification of `FBCache` and `DoubleFBCache` when utilizing the nunchaku feature. This allows for on-the-fly adjustments of cache thresholds, enabling a dynamic trade-off between inference speed and output quality without needing to restart the application.

🚨 Important Dependency
For this implementation to function correctly, the updates from PR #452 must be applied first. Please ensure that the changes from https://github.com/mit-han-lab/nunchaku/pull/452 are merged before this PR.


Performance was measured on an **NVIDIA A5000 GPU**.

Additionally, it's worth noting that the efficiency of both `FBCache` and `DoubleFBCache` increases with larger step sizes.


#### FBCache Performance

For `FBCache`, I evaluated performance based on both `residual_diff_threshold` and `residual_diff_threshold_single`.

**Inference Time (seconds)**
The table below summarizes the inference time for different threshold combinations.

| No FBCache (40s) | FBCache (th=0.2, 12s) | DoubleFBCache (th=0.2/0.2, 12s) |
| :---: | :---: | :---: |
| <img src="https://github.com/user-attachments/assets/82bf2d3b-33f5-4db1-8a81-46e751741b1b" width="300"> | <img src="https://github.com/user-attachments/assets/81a6ad17-b5db-41a2-b150-e3aa456f850e" width="300"> | <img src="https://github.com/user-attachments/assets/51daf86f-c6d0-4892-9109-b05b30515734" width="300"> |